### PR TITLE
Additions to std:account:create and client changes

### DIFF
--- a/connector-spec.json
+++ b/connector-spec.json
@@ -45,7 +45,7 @@
 		}
 	],
 	"accountSchema":{
-		"displayAttribute": "full_name",
+		"displayAttribute": "email_address",
 		"identityAttribute": "user_id",
         "groupAttribute": "groups",
 		"attributes":[

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -170,7 +170,7 @@ export class HTTPClient {
     }
 
     //Updates user status attribute to either 'I' (inactive) or 'A' (active)
-    async changeAccountStatus(userId: string, userStatus: string): Promise<AxiosResponse> {
+    async updateUser(userId: string, requestBody: object): Promise<AxiosResponse> {
         const api_key = this.api_key
         let request: AxiosRequestConfig = {
             method: 'put',
@@ -180,9 +180,7 @@ export class HTTPClient {
                 Authorization: `Bearer ${api_key}`,
                 Accept: 'application/json',
             },
-            data: {
-                status: userStatus
-            }
+            data: requestBody
         }
 
         return axios(request)

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,6 +127,25 @@ export const connector = async () => {
                     const user = { ...input.attributes, ...{ groups: undefined } }
                     const account_response = await httpClient.createAccount(user)
                     account = await readAccount(account_response.data.user_id)
+
+                    if (input.attributes.groups) {
+                        if (Array.isArray(input.attributes.groups)) {
+                            for (const group of input.attributes.groups) {
+    
+                                await assignUserGroup(account,group)
+                            }
+                        } else if (typeof input.attributes.groups === 'string') {
+                            const change: AttributeChange = {
+                                op: AttributeChangeOp.Add,
+                                attribute: 'safeRoles',
+                                value: input.attributes.safeRoles,
+                            }
+    
+                            await assignUserGroup(account,input.attributes.groups)
+                        }
+                    }
+
+                    account = await readAccount(account_response.data.user_id)
                     logger.info(`New Account Created for ${input.attributes.full_name} - account id is ${account.identity}`)
                 }
 
@@ -137,7 +156,7 @@ export const connector = async () => {
             const account = await readAccount(input.identity)
             logger.debug(`Sending account enable request for ${account.attributes.full_name}`)
             
-            await httpClient.changeAccountStatus(input.identity, 'A')
+            await httpClient.updateUser(input.identity, {"status": "A"})
             
             res.send(await readAccount(input.identity))
         })
@@ -145,7 +164,7 @@ export const connector = async () => {
             const account = await readAccount(input.identity)
             logger.debug(`Sending account disable request for ${account.attributes.full_name}`)
             
-            await httpClient.changeAccountStatus(input.identity, 'I')
+            await httpClient.updateUser(input.identity, {"status": "A"})
             
             res.send(await readAccount(input.identity))
         })

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,7 @@ export const connector = async () => {
             const account = await readAccount(input.identity)
             logger.debug(`Sending account disable request for ${account.attributes.full_name}`)
             
-            await httpClient.updateUser(input.identity, {"status": "A"})
+            await httpClient.updateUser(input.identity, {"status": "I"})
             
             res.send(await readAccount(input.identity))
         })

--- a/src/model/account.ts
+++ b/src/model/account.ts
@@ -13,11 +13,11 @@ export class Account {
             status: object.status,
             user_name: object.user_name,
             full_name: object.full_name,
-            email_address: object.email_address,
+            email_address: object.email_address?.toString() ?? `${object.user_name}@peloton.com`,
             groups: object.groups
         }
         this.identity = this.attributes.user_id?.toString() as string
-        this.uuid = this.attributes.user_name as string
+        this.uuid = this.attributes.email_address?.toString() as string
         this.disabled = (object.status === "I") ? true : false
     }
 }


### PR DESCRIPTION
Modified the std:account:create function to handle entitlement requests so that ISC doesn't send a follow up std:account:update request to provision access included in the std:account:create command. Also modified user update function in api client to be more flexible for future updates that allow for more than just user status changes